### PR TITLE
對齊文章資訊的圖示和文字

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1250,6 +1250,7 @@ figure img {
     white-space: nowrap;
     display: flex;
     margin-right: 1.3rem;
+    align-items: center;
 }
 .meta img {
     height: 1rem;


### PR DESCRIPTION
## ✅ What

我把文章字數、閱讀時間和張貼日期等資訊的圖示和文字對齊了，具體來說是改了 `.post-info > .meta` 的 `align-items` 設定。

本來長這樣：
![圖片](https://github.com/user-attachments/assets/ddd479ff-0ee5-4ed4-8db8-3df1a4402b32)

現在長這樣：
![圖片](https://github.com/user-attachments/assets/da043421-fb91-44b5-9d53-e0a80e975500)


## 🤔 Why

這樣比較好看。

## 👩‍🔬 How to validate

- [x] 文章資訊現在是對齊的
- [ ] 沒有其他有 `meta` class 的元素受到影響

## 🔖 Further reading

[Flexbox cheetsheet](https://flexbox.malven.co)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated styling for `.meta` class to center-align items vertically

<!-- end of auto-generated comment: release notes by coderabbit.ai -->