### PR TITLE
更新 Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     },
     "devDependencies": {
         "autocorrect-node": "^2.13.0",
-        "prettier": "^3.3.3"
+        "prettier": "^3.4.2"
     }
 }


### PR DESCRIPTION
## ✅ What

把 Prettier 更新到最新的 3.4.2。

## 🤔 Why

`yarn.lock` 裡面記載專案需要 `^3.4.2`，`package.json` 卻說需要 `^3.3.3`，導致每次 `yarn install` 都會修改 `yarn.lock` 的內容。不如直接更新 Prettier 到 `3.4.2`，保持相容性的同時也能修好這個問題，順便更新。

## 👩‍🔬 How to validate

- [x] 沒有任何文章內容被 Prettier 重新排版
