### PR TITLE
更新 Prettier 和 Yarn 來和 yarn.lock 一致

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "emtech",
-    "packageManager": "yarn@4.2.2",
+    "packageManager": "yarn@4.6.0",
     "version": "1.0.0",
     "scripts": {
         "build": "node emblog/generate.js",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     },
     "devDependencies": {
         "autocorrect-node": "^2.13.0",
-        "prettier": "^3.5.1"
+        "prettier": "^3.5.2"
     }
 }


### PR DESCRIPTION
## ✅ What

執行完 `yarn install` 後，`yarn.lock` 會被修改，代表 `yarn.lock` 的內容和 `package.json` 不一致。
這個 PR 調整 `package.json` 的內容來讓它和 `yarn.lock` 一樣——更新 `prettier` 到 `3.5.2` 就行了。
對了我也更新 Yarn 到 `4.6.0` 了，因為可以。

## 🤔 Why

確保 lockfile 保持更新才不會出現 works on my machine 問題。
![works on my machine](https://img.shields.io/badge/works_on-my_machine-green
)

## 👩‍🔬 How to validate

- [ ] 能安裝並使用新版的 Yarn
- [ ] `yarn install` 不會導致 `yarn.lock` 被修改

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the package manager to a more recent version.
	- Updated the code formatting tool to its latest minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->