### PR TITLE
讓 PWA 可安裝

### DIFF
--- a/static/icons/site.webmanifest
+++ b/static/icons/site.webmanifest
@@ -1,6 +1,5 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "毛哥EM資訊密技",
     "icons": [
         {
             "src": "/static/icons/android-chrome-192x192.png",
@@ -15,5 +14,6 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "standalone"
+    "display": "minimal-ui",
+    "start_url": "/"
 }


### PR DESCRIPTION
## ✅ What

現在網站可以被安裝了，就像個書籤一樣，但是在你的 Launchpad 或桌面上。

## 🤔 Why

Fixes #46.

## 👩‍🔬 How to validate

- [ ] 用 Firefox 以外 (😓) 的瀏覽器打開 emtech.cc
- [ ] 安裝「毛哥EM資訊秘技」

![圖片](https://github.com/user-attachments/assets/05ba06b8-071e-49c9-927c-6a31979fe822)

## 🔖 Further reading

[`display`](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/display) 被改成 `minimal-ui` 了，因為網站現在沒有返回功能，這樣設定操作起來會比較容易。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The application now showcases the clear identity "毛哥EM資訊密技".
  - The launch experience has been refined with a minimal user interface mode.
  - A designated start point has been introduced to ensure a consistent launch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->