### PR TITLE
fix: 不要 ignore .gitignore 文章的 ignore 拼法

### DIFF
--- a/post/git-ignore-gitignore/index.md
+++ b/post/git-ignore-gitignore/index.md
@@ -6,7 +6,7 @@ date: 2025-05-11
 description: `.gitignore` 能不能 ignore 自己？可以。
 ---
 
-# 如果在 .gitignore ignore .gitignore 那 .gitignore 會被 git 因為 .gitignore igonore 了 .gitignore 而被 ignore 嗎？
+# 如果在 .gitignore ignore .gitignore 那 .gitignore 會被 git 因為 .gitignore ignore 了 .gitignore 而被 ignore 嗎？
 
 `.gitignore` 是我們非常熟悉的檔案。它負責告訴 Git 哪些檔案「不要納入版本控制」。但有沒有想過**如果我在 `.gitignore` 裡面加上 `.gitignore` 本身，會發生什麼事？它真的會被 ignore 嗎？**
 


### PR DESCRIPTION
## ✅ What

你 ignore 了 .gitignore 文章的 ignore 拼寫，導致沒有被 .gitignore ignore 的拼錯 ignore 進了 git。

## 🤔 Why

如果是 .gitigonore 就不會被 git 當做 .gitignore，這樣 git 就不會 ignore .gitignore 裡面的檔案。

## 👩‍🔬 How to validate

- [ ] 檢查《如果在 .gitignore ignore .gitignore 那 .gitignore 會被 git 因為 .gitignore igonore 了 .gitignore 而被 ignore 嗎？》是不是變成了《如果在 .gitignore ignore .gitignore 那 .gitignore 會被 git 因為 .gitignore ignore 了 .gitignore 而被 ignore 嗎？》。

## 🔖 Further reading

[文章](https://emtech.cc/p/git-ignore-gitignore/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error in the main heading, changing "igonore" to "ignore".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->